### PR TITLE
Resolve validation errors and warnings

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 	{{ partial "head.html" . }}
-	{{ partial "header.html" . }}
 	<body>
+		{{ partial "header.html" . }}
 		<div class="container">
 			{{ block "main" . }}{{ end }}
 		</div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,15 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-	{{ partial "head.html" . }}
-	<body>
-		{{ partial "header.html" . }}
-		<div class="container">
-			{{ block "main" . }}{{ end }}
-		</div>
-		{{ partial "footer.html" . }}
-		{{ partial "custom_footer.html" . }}
-		{{ range .Site.Params.plugins_js }}
-			<script src="{{ . }}"></script>
-		{{ end }}
-	</body>
+{{ partial "head.html" . }}
+<body>
+	{{ partial "header.html" . }}
+	<div class="container">
+		{{ block "main" . }}{{ end }}
+	</div>
+	{{ partial "footer.html" . }}
+	{{ partial "custom_footer.html" . }}
+	{{ range .Site.Params.plugins_js }}
+		<script src="{{ . }}"></script>
+	{{ end }}
+</body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}
-{{ partial "header.html" . }}
 <body>
+	{{ partial "header.html" . }}
 	<div class="content-page outer">
 			<div class="archive-category-wrap divided">
 				<h1 class="page-title archive-category">Posts in: {{ .Title }}</h1>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}
-{{ partial "header.html" . }}
 <body>
+	{{ partial "header.html" . }}
 	{{ partial "article.html" . }}
 	{{ partial "footer.html" . }}
 	{{ partial "custom_footer.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}
-{{ partial "header.html" . }}
 <body>
+	{{ partial "header.html" . }}
 	<div id="container" class="content-page">
 		<div class="divided">
 			<h1 class="page-title">{{ .Title }}</h1>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
       Recent Posts
   	</h1>
 	<div class="content list h-feed">
-		{{ $paginator := .Paginate (where .Pages "Type" "post") }}
+		{{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
 		{{ range $paginator.Pages }}
 			{{ partial "li.html" . }}
 		{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}
-{{ partial "header.html" . }}
 <body>
+	{{ partial "header.html" . }}
 	<div class="site-masthead">
 	<h1>{{ .Site.Title }}</h1>
 	<h2>{{ .Site.Params.subtitle }}</h2>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,7 +5,7 @@
 	<h1>{{ .Site.Title }}</h1>
 	<h2>{{ .Site.Params.subtitle }}</h2>
 	</div>
-<main class="home" id="main" role="main" aria-label="Content">
+<main class="home" id="main" aria-label="Content">
 	<h1 class="content-title divided">
       Recent Posts
   	</h1>

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}
-{{ partial "header.html" . }}
 <body>
+{{ partial "header.html" . }}
 <div id="container" class="archives-page h-feed">
 	<div class="divided">
 		<h1 class="page-title">Archive</h1>
@@ -23,7 +23,7 @@
 				<p class="h-entry" style="padding-bottom: 5px;">
 					<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>
 					{{ if .Title }}
-						<span class="p-name">: <b>{{ .Title }}</b></span> 
+						<span class="p-name">: <b>{{ .Title }}</b></span>
 					{{ else }}
 						<span class="truncated">: {{ .Summary | truncate 100 }}</span>
 					{{ end }}

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -21,7 +21,7 @@
 			{{ $list := (where .Site.Pages "Type" "post") }}
 			{{ range $list }}
 				<p class="h-entry" style="padding-bottom: 5px;">
-					<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>
+					<a href="{{ .Permalink }}" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</time></a>
 					{{ if .Title }}
 						<span class="p-name">: <b>{{ .Title }}</b></span>
 					{{ else }}

--- a/layouts/list.photoshtml.html
+++ b/layouts/list.photoshtml.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}
-{{ partial "header.html" . }}
 <body>
+{{ partial "header.html" . }}
 <div id="container" class="content-page">
 	<div class="divided">
 		<h1 class="page-title">Photos</h1>

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,4 +1,4 @@
-<article class="post h-entry" itemscope="" itemtype="http://schema.org/BlogPosting" id="main" role="article" aria-label="Content">
+<article class="post h-entry" itemscope="" itemtype="http://schema.org/BlogPosting" id="main" aria-label="Content">
 	{{ if .Title }}
 		<div class="divided">
 			<h1 class="post-title p-name" itemprop="name headline">

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,4 +1,4 @@
-<article class="post h-entry" itemscope="" itemtype="http://schema.org/BlogPosting" id="main" role="article" aria-label="Content" }}>
+<article class="post h-entry" itemscope="" itemtype="http://schema.org/BlogPosting" id="main" role="article" aria-label="Content">
 	{{ if .Title }}
 		<div class="divided">
 			<h1 class="post-title p-name" itemprop="name headline">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <header id="header-inner" class="site-masthead inner">
-	<div class="menu">	
-		<nav id="main-nav" class="site-navigation" role="navigation">
+	<div class="menu">
+		<nav id="main-nav" class="site-navigation">
 			<ul>
 				<li><a class="main-nav-link" href="{{ .Site.BaseURL }}">Home</a></li>
 				{{ range .Site.Menus.main }}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,4 +1,4 @@
-<article class="post h-entry" itemscope="" itemtype="http://schema.org/BlogPosting" id="main" role="article" aria-label="Content">
+<article class="post h-entry" itemscope="" itemtype="http://schema.org/BlogPosting" id="main" aria-label="Content">
 	{{ if .Title }}
 		<div class="divided">
 			<h1 class="post-title">

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,5 +1,3 @@
-<meta charset="utf-8">
-<meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <meta name="description" content="{{ .Site.Params.Description }}">
 <meta name="keywords" content="{{ range .Site.Params.Keywords }}{{ . }},{{ end }}">

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,5 +1,5 @@
 <section>
-		<script language="javascript">
+		<script>
 
 var archive_results = {};
 
@@ -50,7 +50,7 @@ function runSearch(q) {
 				results_node.appendChild(p_node);
 			}
 		}
-	} 
+	}
 }
 
 downloadArchive();

--- a/layouts/section/replies.html
+++ b/layouts/section/replies.html
@@ -1,7 +1,7 @@
 {{ partial "head.html" . }}
 <body>
+{{ partial "header.html" . }}
 <div id="container">
-	{{ partial "header.html" . }}
 	<section id="main" class="outer">
 		<section class="archives-wrap">
 			<div class="archive-category-wrap">

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,7 +1,7 @@
 {{ partial "head.html" . }}
 <body>
+{{ partial "header.html" . }}
 <div id="container">
-	{{ partial "header.html" . }}
 	<section id="main" class="outer">
 		<section class="archives-wrap">
 			<div class="archive-tag-wrap">


### PR DESCRIPTION
This pull request aims to resolve most (but not all) [HTML validation errors and warnings](https://validator.w3.org):

- Remove redundant document character set metadata.
- Move `header` element inside `body`.
- Remove stray `}}`.
- Remove unnecessary `role` and `language` attributes.
- Remove extra `DOCTYPE` and `html` element.
- Change from `span` to `time` element.

There's also a bonus commit for better compatibility with Hugo 0.91.0.