### PR TITLE
Remove extra p element and safeHTML

### DIFF
--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -15,7 +15,7 @@
 				<p><a href="{{ .Permalink }}">Continue reading →</a></p>
 			</div>
 		{{ else if .Truncated }}
-			<p>{{ .Content | safeHTML | truncate 200 }}</p>
+			{{ .Content | truncate 200 }}
 			<div class="continue">
 				<p><a href="{{ .Permalink }}">Continue reading →</a></p>
 			</div>


### PR DESCRIPTION
`.Content` is already declared as safe and includes `p` elements. With this change, output like `<p><p>My blog post content […]</p></p>` will be no more.