### PR TITLE
Adds group by date to index page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,10 +10,26 @@
       Recent Posts
   	</h1>
 	<div class="content list h-feed">
-		{{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
-		{{ range $paginator.Pages }}
-			{{ partial "li.html" . }}
-		{{ end }}
+    {{ if .Site.Params.daygroup }}
+      {{ $posts := where .Site.Pages "Type" "post" }}
+      {{ $grouped := $posts.GroupByDate "2006-01-02" }}
+      {{ $paginated := (.Paginate ($grouped)) }}
+      {{ range $paginated.PageGroups }}
+        {{ $thedate :=(time .Key) }}
+         <div class="day">
+           <span class="dateheader">
+             {{ $thedate.Format "January 2, 2006" }}
+           </span>
+           {{ range .Pages.Reverse }}
+		    	   {{ partial "li.html" . }}
+           {{ end }}
+      {{ end }}
+    {{ else }}
+		  {{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
+		  {{ range $paginator.Pages }}
+		  	{{ partial "li.html" . }}
+		  {{ end }}
+    {{ end }}
 		<!--{{ partial "pagination.html" . }}-->
 	</div>
 	<div class="archive">

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"title": "Hitchens theme",
 	"description": "Changes your blog to use the Hitchens theme. Set the built-in design to Blank.",
 	"fields": [
@@ -12,6 +12,11 @@
 			"field": "params.description",
 			"label": "Description",
 			"placeholder": "Enter your description here"
-		}
+		},
+    {
+      "field": "params.daygroup",
+      "label": "Group posts by day",
+      "type": "boolean"
+    }
 	]
 }


### PR DESCRIPTION
This should add a boolean that lets someone group their posts by day like I do on json.blog. I did not add any CSS for the added `day` div or `dateheader` span, because I don't use Hitchens so I'm not sure how to make those look "right". I would expect a desire to play with that before merging this PR.